### PR TITLE
Emoji picker UI updates pt3

### DIFF
--- a/Demo.xcodeproj/project.pbxproj
+++ b/Demo.xcodeproj/project.pbxproj
@@ -101,6 +101,7 @@
 				371336FE29BBF51C00952B29 /* Sources */,
 				371336FF29BBF51C00952B29 /* Frameworks */,
 				3713370029BBF51C00952B29 /* Resources */,
+				D67C5811298BCAE883E4AE4A /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -182,6 +183,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		D67C5811298BCAE883E4AE4A /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Demo/Pods-Demo-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Demo/Pods-Demo-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Demo/Pods-Demo-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/Podfile
+++ b/Podfile
@@ -6,6 +6,7 @@ install! 'cocoapods', :share_schemes_for_development_pods => ['ElegantEmojiPicke
 target 'Demo' do
     use_frameworks!
     platform :ios, '16.0'
+    pod 'ElegantEmojiPicker', :path => '.'
 end
 
 post_install do |installer|

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,3 +1,16 @@
-PODFILE CHECKSUM: b7c6ee9eafe6da0ec24b85e584efe5d22b566f35
+PODS:
+  - ElegantEmojiPicker (1.0)
+
+DEPENDENCIES:
+  - ElegantEmojiPicker (from `.`)
+
+EXTERNAL SOURCES:
+  ElegantEmojiPicker:
+    :path: "."
+
+SPEC CHECKSUMS:
+  ElegantEmojiPicker: 1e1943cc332c227bccce7759b42a123ef8c1fa64
+
+PODFILE CHECKSUM: 62f8694cbe47a68d0c242d6fa0989bb8bd9ff63b
 
 COCOAPODS: 1.16.2

--- a/Sources/Definitions.swift
+++ b/Sources/Definitions.swift
@@ -10,26 +10,6 @@ import UIKit
 import CoreText
 
 /// Struct representing a single emoji
-public extension Bundle {
-    static func moduleBundle(named name: String, for cls: AnyClass) -> Bundle {
-        let bundle = Bundle(for: cls)
-
-        guard let path = bundle.path(forResource: name, ofType: "bundle") else {
-            return bundle
-        }
-
-        return Bundle(path: path) ?? bundle
-    }
-}
-
-internal extension Bundle {
-    static var moduleBundle: Bundle {
-        return self.moduleBundle(named: "GLCore", for: BundleToken.self)
-    }
-}
-
-private final class BundleToken {}
-
 public struct Emoji: Decodable, Equatable {
     public let emoji: String
     public let description: String
@@ -171,8 +151,10 @@ public enum EmojiCategory: String, CaseIterable, Decodable {
     
     public var image: UIImage? {
         switch self {
-        case .PeopleAndBody: return UIImage(systemName: "hand.wave", withConfiguration: UIImage.SymbolConfiguration(weight: .medium))?.withRenderingMode(.alwaysTemplate)
-        default: return UIImage(named: self.rawValue, in: .moduleBundle, with: nil)?.withRenderingMode(.alwaysTemplate)
+        case .PeopleAndBody:
+            return UIImage(systemName: "hand.wave", withConfiguration: UIImage.SymbolConfiguration(weight: .medium))?.withRenderingMode(.alwaysTemplate)
+        default:
+            return UIImage(named: self.rawValue, in: .moduleBundle, with: nil)?.withRenderingMode(.alwaysTemplate)
         }
     }
     

--- a/Sources/Definitions.swift
+++ b/Sources/Definitions.swift
@@ -10,6 +10,26 @@ import UIKit
 import CoreText
 
 /// Struct representing a single emoji
+public extension Bundle {
+    static func moduleBundle(named name: String, for cls: AnyClass) -> Bundle {
+        let bundle = Bundle(for: cls)
+
+        guard let path = bundle.path(forResource: name, ofType: "bundle") else {
+            return bundle
+        }
+
+        return Bundle(path: path) ?? bundle
+    }
+}
+
+internal extension Bundle {
+    static var moduleBundle: Bundle {
+        return self.moduleBundle(named: "GLCore", for: BundleToken.self)
+    }
+}
+
+private final class BundleToken {}
+
 public struct Emoji: Decodable, Equatable {
     public let emoji: String
     public let description: String
@@ -152,7 +172,7 @@ public enum EmojiCategory: String, CaseIterable, Decodable {
     public var image: UIImage? {
         switch self {
         case .PeopleAndBody: return UIImage(systemName: "hand.wave", withConfiguration: UIImage.SymbolConfiguration(weight: .medium))?.withRenderingMode(.alwaysTemplate)
-        default: return UIImage(named: self.rawValue, in: .module, with: nil)?.withRenderingMode(.alwaysTemplate)
+        default: return UIImage(named: self.rawValue, in: .moduleBundle, with: nil)?.withRenderingMode(.alwaysTemplate)
         }
     }
     

--- a/Sources/ElegantEmojiPicker.swift
+++ b/Sources/ElegantEmojiPicker.swift
@@ -52,6 +52,8 @@ open class ElegantEmojiPicker: UIViewController {
     let padding = 16.0
     let topElementHeight = 40.0
     
+    let backgroundBlur = UIVisualEffectView(effect: UIBlurEffect(style: .systemUltraThinMaterial))
+
     var searchFieldBackground: UIVisualEffectView?
     var searchField: UITextField?
     var clearButton: UIButton?
@@ -100,7 +102,23 @@ open class ElegantEmojiPicker: UIViewController {
         super.init(nibName: nil, bundle: nil)
         
         self.emojiSections = self.delegate?.emojiPicker(self, loadEmojiSections: config, localization) ?? ElegantEmojiPicker.getDefaultEmojiSections(config: config, localization: localization)
-                
+
+        if let sourceView = sourceView, !AppConfiguration.isIPhone, AppConfiguration.windowFrame.width > 500 {
+            self.modalPresentationStyle = .popover
+            self.popoverPresentationController?.sourceView = sourceView
+        } else if let sourceNavigationBarButton = sourceNavigationBarButton, !AppConfiguration.isIPhone, AppConfiguration.windowFrame.width > 500 {
+            self.modalPresentationStyle = .popover
+            self.popoverPresentationController?.barButtonItem = sourceNavigationBarButton
+        } else {
+            self.modalPresentationStyle = .formSheet
+            if #available(iOS 15.0, *) {
+                self.sheetPresentationController?.prefersGrabberVisible = true
+                self.sheetPresentationController?.detents = [.medium(), .large()]
+            }
+        }
+
+        self.presentationController?.delegate = self
+
         if config.showSearch {
             searchFieldBackground = UIVisualEffectView(effect: UIBlurEffect(style: .systemUltraThinMaterial))
             searchFieldBackground!.layer.cornerRadius = 8
@@ -491,6 +509,11 @@ extension ElegantEmojiPicker {
     }
 }
 
+extension ElegantEmojiPicker: UIAdaptivePresentationControllerDelegate {
+    public func adaptivePresentationStyle(for controller: UIPresentationController) -> UIModalPresentationStyle {
+        return .none // Do not adapt presentation style. We set the presentation style manually in our init(). I know better than Apple.
+    }
+}
 
 //MARK: Static methods
 

--- a/Sources/ElegantEmojiPicker.swift
+++ b/Sources/ElegantEmojiPicker.swift
@@ -9,8 +9,6 @@ import Foundation
 import UIKit
 import SwiftUI
 
-/// Present this view controller when you want to offer users emoji selection. Conform to its delegate ElegantEmojiPickerDelegate and pass it to the view controller to interact with it and receive user's selection.
-///
 public struct EmojiPickerView: UIViewControllerRepresentable {
     @Binding public var emojiString: String?
     
@@ -40,9 +38,10 @@ public struct EmojiPickerView: UIViewControllerRepresentable {
 
     public func updateUIViewController(_ uiViewController: UIViewControllerType, context: Context) {
     }
-    
 }
 
+/// Present this view controller when you want to offer users emoji selection. Conform to its delegate ElegantEmojiPickerDelegate and pass it to the view controller to interact with it and receive user's selection.
+///
 open class ElegantEmojiPicker: UIViewController {
     required public init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
     
@@ -77,7 +76,6 @@ open class ElegantEmojiPicker: UIViewController {
     var skinToneSelector: SkinToneSelector?
     var emojiPreview: EmojiPreview?
     public var previewingEmoji: Emoji?
-    public var previewingEmojiString: String?
     
     var emojiSections = [EmojiSection]()
     var searchResults: [Emoji]?
@@ -231,9 +229,6 @@ open class ElegantEmojiPicker: UIViewController {
     
     func didSelectEmoji (_ emoji: Emoji?) {
         delegate?.emojiPicker(self, didSelectEmoji: emoji)
-        previewingEmoji = emoji
-        previewingEmojiString = emoji?.emoji
-//        if delegate?.emojiPickerShouldDismissAfterSelection(self) ?? true { self.dismiss(animated: true) }
     }
 }
 

--- a/Sources/ElegantEmojiPicker.swift
+++ b/Sources/ElegantEmojiPicker.swift
@@ -24,7 +24,7 @@ public struct EmojiPickerView: UIViewControllerRepresentable {
         }
         
         public func emojiPicker(_ picker: ElegantEmojiPicker, didSelectEmoji emoji: Emoji?) {
-            parent.emojiString = emoji?.emoji ?? nil
+            parent.emojiString = emoji?.emoji
         }
     }
     

--- a/Sources/ElegantEmojiPicker.swift
+++ b/Sources/ElegantEmojiPicker.swift
@@ -47,6 +47,7 @@ open class ElegantEmojiPicker: UIViewController {
     public weak var delegate: ElegantEmojiPickerDelegate?
     public let config: ElegantConfiguration
     public let localization: ElegantLocalization
+    @Environment(\.locale) private var locale
     
     let padding = 16.0
     let topElementHeight = 40.0
@@ -117,7 +118,9 @@ open class ElegantEmojiPicker: UIViewController {
         }
         
         self.presentationController?.delegate = self
-        if config.showSearch {
+        if config.showSearch && Locale.current.language.languageCode?.identifier == "en" {
+            searchFieldBackground = UIVisualEffectView()
+            searchFieldBackground?.backgroundColor = .systemBackground
             searchFieldBackground = UIVisualEffectView(effect: UIBlurEffect(style: .systemUltraThinMaterial))
             searchFieldBackground!.layer.cornerRadius = 8
             searchFieldBackground!.clipsToBounds = true
@@ -222,12 +225,12 @@ open class ElegantEmojiPicker: UIViewController {
     
     public override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
-        collectionLayout.headerReferenceSize = CGSize(width: collectionView.frame.width, height: 50)
+        collectionLayout.headerReferenceSize = Locale.current.language.languageCode?.identifier == "en" ? CGSize(width: collectionView.frame.width, height: 50) : .zero
         fadeContainer.layer.mask?.frame = fadeContainer.bounds
     }
     
     public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        self.view.backgroundColor = UIScreen.main.traitCollection.userInterfaceStyle == .light ? .black.withAlphaComponent(0.1) : .clear
+        self.view.backgroundColor = .clear
     }
     
     @objc func TappedClose () {

--- a/Sources/ElegantEmojiPicker.swift
+++ b/Sources/ElegantEmojiPicker.swift
@@ -6,8 +6,8 @@
 //
 
 import Foundation
-import UIKit
 import SwiftUI
+import UIKit
 
 public struct EmojiPickerView: UIViewControllerRepresentable {
     @Binding public var emojiString: String?
@@ -24,7 +24,7 @@ public struct EmojiPickerView: UIViewControllerRepresentable {
         }
         
         public func emojiPicker(_ picker: ElegantEmojiPicker, didSelectEmoji emoji: Emoji?) {
-            parent.emojiString = emoji?.emoji ?? ""
+            parent.emojiString = emoji?.emoji ?? nil
         }
     }
     
@@ -41,7 +41,6 @@ public struct EmojiPickerView: UIViewControllerRepresentable {
 }
 
 /// Present this view controller when you want to offer users emoji selection. Conform to its delegate ElegantEmojiPickerDelegate and pass it to the view controller to interact with it and receive user's selection.
-///
 open class ElegantEmojiPicker: UIViewController {
     required public init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
     
@@ -102,7 +101,7 @@ open class ElegantEmojiPicker: UIViewController {
         super.init(nibName: nil, bundle: nil)
         
         self.emojiSections = self.delegate?.emojiPicker(self, loadEmojiSections: config, localization) ?? ElegantEmojiPicker.getDefaultEmojiSections(config: config, localization: localization)
-
+        
         if let sourceView = sourceView, !AppConfiguration.isIPhone, AppConfiguration.windowFrame.width > 500 {
             self.modalPresentationStyle = .popover
             self.popoverPresentationController?.sourceView = sourceView
@@ -116,9 +115,8 @@ open class ElegantEmojiPicker: UIViewController {
                 self.sheetPresentationController?.detents = [.medium(), .large()]
             }
         }
-
+        
         self.presentationController?.delegate = self
-
         if config.showSearch {
             searchFieldBackground = UIVisualEffectView(effect: UIBlurEffect(style: .systemUltraThinMaterial))
             searchFieldBackground!.layer.cornerRadius = 8
@@ -514,6 +512,7 @@ extension ElegantEmojiPicker: UIAdaptivePresentationControllerDelegate {
         return .none // Do not adapt presentation style. We set the presentation style manually in our init(). I know better than Apple.
     }
 }
+
 
 //MARK: Static methods
 

--- a/Sources/ElegantEmojiPicker.swift
+++ b/Sources/ElegantEmojiPicker.swift
@@ -52,7 +52,7 @@ open class ElegantEmojiPicker: UIViewController {
     let topElementHeight = 40.0
     
     let backgroundBlur = UIVisualEffectView(effect: UIBlurEffect(style: .systemUltraThinMaterial))
-
+    
     var searchFieldBackground: UIVisualEffectView?
     var searchField: UITextField?
     var clearButton: UIButton?

--- a/Sources/ElegantEmojiPicker.swift
+++ b/Sources/ElegantEmojiPicker.swift
@@ -134,7 +134,7 @@ open class ElegantEmojiPicker: UIViewController {
             searchFieldBackground?.backgroundColor = backgroundColor
             searchFieldBackground!.layer.cornerRadius = 8
             searchFieldBackground?.layer.borderWidth = 1
-            searchFieldBackground?.layer.borderColor = borderStrokeColor?.cgColor
+            searchFieldBackground?.layer.borderColor = borderStrokeColor?.withAlphaComponent(0.6).cgColor
             searchFieldBackground!.clipsToBounds = true
             searchFieldBackground!.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(TappedSearchBackground)))
             self.view.addSubview(searchFieldBackground!, anchors: [.safeAreaLeading(padding), .safeAreaTop(padding*1.5), .height(topElementHeight)])

--- a/Sources/Extensions/Bundle+Module.swift
+++ b/Sources/Extensions/Bundle+Module.swift
@@ -1,0 +1,25 @@
+//
+//  Bundle+Module.swift
+//  Pods
+//
+//  Created by Lakshya Nagal on 5/2/25.
+//
+public extension Bundle {
+    static func moduleBundle(named name: String, for cls: AnyClass) -> Bundle {
+        let bundle = Bundle(for: cls)
+
+        guard let path = bundle.path(forResource: name, ofType: "bundle") else {
+            return bundle
+        }
+
+        return Bundle(path: path) ?? bundle
+    }
+}
+
+internal extension Bundle {
+    static var moduleBundle: Bundle {
+        return self.moduleBundle(named: "GLCore", for: BundleToken.self)
+    }
+}
+
+private final class BundleToken {}

--- a/Sources/Extensions/Bundle+Module.swift
+++ b/Sources/Extensions/Bundle+Module.swift
@@ -4,6 +4,8 @@
 //
 //  Created by Lakshya Nagal on 5/2/25.
 //
+import Foundation
+
 public extension Bundle {
     static func moduleBundle(named name: String, for cls: AnyClass) -> Bundle {
         let bundle = Bundle(for: cls)


### PR DESCRIPTION
Changes we are making: 
1. Get rid of Blur effect and background for the picker
2. Only show search and categories if you are in English region
3. fix the search field to match our Subject Text field in stroke and color (both light + dark mode)

### Screenshots: 
Light mode:
<img width="363" alt="Screenshot 2025-05-07 at 11 46 53 AM" src="https://github.com/user-attachments/assets/61b5ca3d-2c2f-4073-ac9e-33034ca82399" />

Dark mode:
<img width="368" alt="Screenshot 2025-05-07 at 11 46 36 AM" src="https://github.com/user-attachments/assets/03191dc8-e63d-4af6-8ad2-69a18f31d09d" />

### Test Steps
<!-- What to test and how to test it. The tests you ran, big picture impact, and edge cases. Include instructions on setup process and version information, if needed. -->
- [ ] Turn on .emojifyingSubjects feature flag
- [ ] Open Library --> Subjects --> long press to click edit
- [ ] Check that the picker toggle works, as well as selecting emojis updates the preview on top left
- [ ] Try out the search bar, should be able to search up most emojis
- [ ] Change Language for device to anything other than English, should not see the search bar or the categories.

### Dev QA
@zackcmartin please!